### PR TITLE
Fix header job title spelling

### DIFF
--- a/src/routes/landing/HeaderPreview.tsx
+++ b/src/routes/landing/HeaderPreview.tsx
@@ -8,7 +8,7 @@ const HeaderPreview = () => {
         <em className="blue-text">Mario Vargas</em>
         <br></br>Warlock Developer 
       </h1>
-      <p className="gray-text p-tag">FullStack Developer</p>
+      <p className="gray-text p-tag">Full-stack Developer</p>
       <Link className="blue-text" to="/portfolio">
         Check my work
       </Link>


### PR DESCRIPTION
## Summary
- standardize job title wording to **Full-stack Developer**

## Testing
- `npm run lint` *(fails: ESLint couldn't find a configuration file)*

------
https://chatgpt.com/codex/tasks/task_e_6843fe68fc24832ea4fa9bfff296fe57