### PR TITLE
refactor: Remove z-index from overlay styles

### DIFF
--- a/src/components/overlay/Overlay.module.css
+++ b/src/components/overlay/Overlay.module.css
@@ -10,7 +10,6 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  z-index: 1500;
 }
 
 .text {


### PR DESCRIPTION
there was an issue with the settings button, the overlay z-index was making issues with the interaction with the button